### PR TITLE
Added field for personal email id in User Profile Page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,13 +1,14 @@
 class UsersController < ApplicationController
   before_action :require_login
   # sysadmin-only actions; allow index/show/profile for regular users
-  before_action :require_sysadmin, except: [ :index, :show, :profile ]
+  before_action :require_sysadmin, except: [ :index, :show, :profile, :edit, :update ]
   before_action :set_user, only: [ :show, :edit, :update, :destroy ]
+
+  before_action :correct_user, only: [:edit, :update]
 
   def index
     @users = User.order(:id)
   end
-
   def show; end
 
   # Show current user's profile
@@ -52,10 +53,15 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
-  # Only sysadmins may set role; everyone else (not that they can reach here) gets role filtered out.
+  def correct_user
+    unless sysadmin? || current_user == @user
+      redirect_to root_path, alert: "You are not authorized to edit this profile."
+    end
+  end
+
   def user_params
     permitted = [
-      :provider, :uid, :email, :name, :image_url,
+      :provider, :uid, :email, :personal_email, :name, :image_url, # Added :personal_email here
       :access_token, :refresh_token, :access_token_expires_at
     ]
     permitted << :role if sysadmin?

--- a/app/mailers/ticket_mailer.rb
+++ b/app/mailers/ticket_mailer.rb
@@ -5,6 +5,8 @@ class TicketMailer < ApplicationMailer
         @ticket = params[:ticket]
         @user = @ticket.requester
 
-        mail(to: @user.email, subject: "[Ticket ##{@ticket.id}] Update: #{@ticket.subject}")
+        recipient_email = @user.personal_email.present? ? @user.personal_email : @user.email
+
+        mail(to: recipient_email, subject: "[Ticket ##{@ticket.id}] Update: #{@ticket.subject}")
     end
 end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -16,6 +16,11 @@
     </div>
 
     <div class="form-field">
+      <%= f.label :personal_email %><br>
+      <%= f.email_field :personal_email, required: true, autofocus: true %>
+    </div>
+
+    <div class="form-field">
       <%= f.label :name %><br>
       <%= f.text_field :name %>
     </div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,5 +1,4 @@
 <div class="container user-profile">
-  
 
   <div class="headline-bar">
     <h1>My Profile</h1>
@@ -25,6 +24,14 @@
           <dt>Email</dt>
           <dd><%= mail_to @user.email %></dd>
 
+          <dt>Personal Email</dt>
+          <dd>
+            <% if @user.personal_email.present? %>
+              <%= mail_to @user.personal_email %>
+            <% else %>
+              <span style="color: #999;">Not provided</span>
+            <% end %>
+          </dd>
           <dt>Role</dt>
           <dd><span class="role-badge role-<%= @user.role %>"><%= @user.role.titleize %></span></dd>
 

--- a/db/migrate/20251130055843_add_personal_email_to_users.rb
+++ b/db/migrate/20251130055843_add_personal_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddPersonalEmailToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :personal_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_01_120200) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_30_055843) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -109,6 +109,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_01_120200) do
     t.string "refresh_token"
     t.datetime "access_token_expires_at"
     t.integer "role", default: 0, null: false
+    t.string "personal_email"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["role"], name: "index_users_on_role"


### PR DESCRIPTION
Personal Email ID field added as emails arent getting mailed to TAMU mail accounts. Users can add their personal email ids here and the update emails get delivered to that account. 